### PR TITLE
nullify server object on shutdown

### DIFF
--- a/schemaregistry-junit-core/src/main/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResource.java
+++ b/schemaregistry-junit-core/src/main/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResource.java
@@ -131,6 +131,7 @@ public class SchemaRegistryTestResource<T extends SchemaRegistryTestResource> {
     validateServerDoesNotExist("Schema-registry test server does not exist yet!");
 
     server.stop();
+    server = null;
   }
 
   /**

--- a/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
+++ b/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
@@ -6,7 +6,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.List;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -82,7 +82,7 @@ class SchemaRegistryTestResourceLifecycleTest {
 
     assertThatCode(() -> kafka.getKafkaTestUtils()
             .getAdminClient()
-            .deleteTopics(List.of("_schemas")).all().get())
+            .deleteTopics(Collections.singletonList("_schemas")).all().get())
             .doesNotThrowAnyException();
 
     Thread.sleep(2_000L);

--- a/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
+++ b/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
@@ -13,125 +13,87 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 class SchemaRegistryTestResourceLifecycleTest {
 
-    @RegisterExtension
-    public static final SharedKafkaTestResource kafka = new SharedKafkaTestResource()
-            .withBrokers(1);
+  @RegisterExtension
+  public static final SharedKafkaTestResource kafka = new SharedKafkaTestResource()
+          .withBrokers(1);
 
-    private static final String TOPIC = "test-scenario-string-json";
+  private static final String TOPIC = "test-scenario-string-json";
 
-    private static final String SCHEMA = "{"
-            + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
-            + "\"title\":\"User\","
-            + "\"type\":\"object\","
-            + "\"additionalProperties\":false,"
-            + "\"properties\":{"
-            + "\"firstName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
-            + "{\"type\":\"string\"}]},"
-            + "\"lastName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
-            + "{\"type\":\"string\"}]}}}";
+  private static final String SCHEMA = "{"
+          + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+          + "\"title\":\"User\","
+          + "\"type\":\"object\","
+          + "\"additionalProperties\":false,"
+          + "\"properties\":{"
+          + "\"firstName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+          + "{\"type\":\"string\"}]},"
+          + "\"lastName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+          + "{\"type\":\"string\"}]}}}";
 
-    @Test
-    @SneakyThrows
-    void shouldBeAbleToAccessSchemasAfterSchemaRegistryTestResourceRestart() {
-        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
-                .withBootstrapServers(kafka.getKafkaConnectString())
-                .withRandomPort();
+  @Test
+  @SneakyThrows
+  void shouldBeAbleToAccessSchemasAfterSchemaRegistryTestResourceRestart() {
+    SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+            .withBootstrapServers(kafka.getKafkaConnectString())
+            .withRandomPort();
 
-        assertThatCode(schemaRegistry::start)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
 
-        assertThatCode(() -> schemaRegistry
-                .schemaRegistryTestUtils()
-                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
+    assertThatCode(() -> schemaRegistry
+            .schemaRegistryTestUtils()
+            .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
 
-        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(1);
+    assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+            .hasSize(1);
 
-        assertThatCode(schemaRegistry::shutdown)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
 
-        assertThatCode(schemaRegistry::start)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
 
-        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(1);
+    assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+            .hasSize(1);
 
-        assertThatCode(schemaRegistry::shutdown)
-                .doesNotThrowAnyException();
-    }
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
+  }
 
-    @Test
-    @SneakyThrows
-    void shouldNotBeAbleToAccessSchemasOnEmptySchemasTopic() {
-        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
-                .withBootstrapServers(kafka.getKafkaConnectString())
-                .withRandomPort();
+  @Test
+  @SneakyThrows
+  void shouldNotBeAbleToAccessSchemasOnEmptySchemasTopic() {
+    SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+            .withBootstrapServers(kafka.getKafkaConnectString())
+            .withRandomPort();
 
-        assertThatCode(schemaRegistry::start)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
 
-        assertThatCode(() -> schemaRegistry
-                .schemaRegistryTestUtils()
-                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
+    assertThatCode(() -> schemaRegistry
+            .schemaRegistryTestUtils()
+            .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
 
-        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(1);
+    assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+            .hasSize(1);
 
-        assertThatCode(schemaRegistry::shutdown)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
 
-        assertThatCode(() -> kafka.getKafkaTestUtils().getAdminClient().deleteTopics(List.of("_schemas")))
-                .doesNotThrowAnyException();
+    assertThatCode(() -> kafka.getKafkaTestUtils()
+            .getAdminClient()
+            .deleteTopics(List.of("_schemas")).all().get())
+            .doesNotThrowAnyException();
 
-        SchemaRegistryTestResource<?> schemaRegistry2 = new SchemaRegistryTestResource<>()
-                .withBootstrapServers(kafka.getKafkaConnectString())
-                .withRandomPort();
+    Thread.sleep(2_000L);
 
-        assertThatCode(schemaRegistry::start)
-                .doesNotThrowAnyException();
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
 
-        assertThat(schemaRegistry2.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(1);
+    assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+            .isEmpty();
 
-        assertThatCode(schemaRegistry2::shutdown)
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @SneakyThrows
-    void shouldNotBeAbleToAccessSchemasOnEmptySchemasTopicWithSeperateKafkaInstances() {
-        SharedKafkaTestResource kafka2 = new SharedKafkaTestResource()
-                .withBrokers(1);
-        kafka2.beforeAll(null); // Required as we need an ExecutionContext we don't have access to
-
-        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
-                .withBootstrapServers(kafka.getKafkaConnectString())
-                .withRandomPort();
-
-        assertThatCode(schemaRegistry::start)
-                .doesNotThrowAnyException();
-
-        assertThatCode(() -> schemaRegistry
-                .schemaRegistryTestUtils()
-                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
-
-        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(1);
-
-        assertThatCode(schemaRegistry::shutdown)
-                .doesNotThrowAnyException();
-
-        SchemaRegistryTestResource<?> schemaRegistry2 = new SchemaRegistryTestResource<>()
-                .withBootstrapServers(kafka2.getKafkaConnectString())
-                .withRandomPort();
-
-        assertThatCode(schemaRegistry2::start)
-                .doesNotThrowAnyException();
-
-        assertThat(schemaRegistry2.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
-                .hasSize(0);
-
-        assertThatCode(schemaRegistry2::shutdown)
-                .doesNotThrowAnyException();
-    }
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
+  }
 }

--- a/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
+++ b/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceLifecycleTest.java
@@ -1,0 +1,137 @@
+package com.datarocks.schemaregistry.test;
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class SchemaRegistryTestResourceLifecycleTest {
+
+    @RegisterExtension
+    public static final SharedKafkaTestResource kafka = new SharedKafkaTestResource()
+            .withBrokers(1);
+
+    private static final String TOPIC = "test-scenario-string-json";
+
+    private static final String SCHEMA = "{"
+            + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+            + "\"title\":\"User\","
+            + "\"type\":\"object\","
+            + "\"additionalProperties\":false,"
+            + "\"properties\":{"
+            + "\"firstName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+            + "{\"type\":\"string\"}]},"
+            + "\"lastName\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+            + "{\"type\":\"string\"}]}}}";
+
+    @Test
+    @SneakyThrows
+    void shouldBeAbleToAccessSchemasAfterSchemaRegistryTestResourceRestart() {
+        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+                .withBootstrapServers(kafka.getKafkaConnectString())
+                .withRandomPort();
+
+        assertThatCode(schemaRegistry::start)
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> schemaRegistry
+                .schemaRegistryTestUtils()
+                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
+
+        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(1);
+
+        assertThatCode(schemaRegistry::shutdown)
+                .doesNotThrowAnyException();
+
+        assertThatCode(schemaRegistry::start)
+                .doesNotThrowAnyException();
+
+        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(1);
+
+        assertThatCode(schemaRegistry::shutdown)
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldNotBeAbleToAccessSchemasOnEmptySchemasTopic() {
+        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+                .withBootstrapServers(kafka.getKafkaConnectString())
+                .withRandomPort();
+
+        assertThatCode(schemaRegistry::start)
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> schemaRegistry
+                .schemaRegistryTestUtils()
+                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
+
+        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(1);
+
+        assertThatCode(schemaRegistry::shutdown)
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> kafka.getKafkaTestUtils().getAdminClient().deleteTopics(List.of("_schemas")))
+                .doesNotThrowAnyException();
+
+        SchemaRegistryTestResource<?> schemaRegistry2 = new SchemaRegistryTestResource<>()
+                .withBootstrapServers(kafka.getKafkaConnectString())
+                .withRandomPort();
+
+        assertThatCode(schemaRegistry::start)
+                .doesNotThrowAnyException();
+
+        assertThat(schemaRegistry2.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(1);
+
+        assertThatCode(schemaRegistry2::shutdown)
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldNotBeAbleToAccessSchemasOnEmptySchemasTopicWithSeperateKafkaInstances() {
+        SharedKafkaTestResource kafka2 = new SharedKafkaTestResource()
+                .withBrokers(1);
+        kafka2.beforeAll(null); // Required as we need an ExecutionContext we don't have access to
+
+        SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+                .withBootstrapServers(kafka.getKafkaConnectString())
+                .withRandomPort();
+
+        assertThatCode(schemaRegistry::start)
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> schemaRegistry
+                .schemaRegistryTestUtils()
+                .schemaRegistryClient().register(TOPIC + "-value", new JsonSchema(SCHEMA)));
+
+        assertThat(schemaRegistry.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(1);
+
+        assertThatCode(schemaRegistry::shutdown)
+                .doesNotThrowAnyException();
+
+        SchemaRegistryTestResource<?> schemaRegistry2 = new SchemaRegistryTestResource<>()
+                .withBootstrapServers(kafka2.getKafkaConnectString())
+                .withRandomPort();
+
+        assertThatCode(schemaRegistry2::start)
+                .doesNotThrowAnyException();
+
+        assertThat(schemaRegistry2.schemaRegistryTestUtils().schemaRegistryClient().getAllSubjects())
+                .hasSize(0);
+
+        assertThatCode(schemaRegistry2::shutdown)
+                .doesNotThrowAnyException();
+    }
+}

--- a/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceTest.java
+++ b/schemaregistry-junit-core/src/test/java/com/datarocks/schemaregistry/test/SchemaRegistryTestResourceTest.java
@@ -218,4 +218,23 @@ class SchemaRegistryTestResourceTest {
         .isThrownBy(schemaRegistry::shutdown)
         .withMessage("Schema-registry test server does not exist yet!");
   }
+
+  @Test
+  void shouldNullServerAfterCallingShutdown() {
+    SchemaRegistryTestResource<?> schemaRegistry = new SchemaRegistryTestResource<>()
+            .withProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG,
+                    kafka.getKafkaConnectString());
+
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
+
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
+
+    assertThatCode(schemaRegistry::start)
+            .doesNotThrowAnyException();
+
+    assertThatCode(schemaRegistry::shutdown)
+            .doesNotThrowAnyException();
+  }
 }


### PR DESCRIPTION
Nulls the server on shutdown to allow future tests to create a new server instance.

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

