### PR TITLE
Move to Java11 with Java8 compatibility

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/gradle-example.yml
+++ b/.github/workflows/gradle-example.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Set dependency versions
         run: ./gradlew setDependenciesForExample
       - name: Switch to JDK 1.8
-          uses: actions/setup-java@v1
-          with:
-            java-version: 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
       - name: Run Junit5 example
         run: cd ./examples/junit-5 && ./gradlew build
       - name: Run Junit4 example

--- a/.github/workflows/gradle-example.yml
+++ b/.github/workflows/gradle-example.yml
@@ -27,8 +27,6 @@ jobs:
         run: ./gradlew publishToMavenLocal -PdisableCheckstyle -PdisableJacoco -PdisablePmd -x test
       - name: Set dependency versions
         run: ./gradlew setDependenciesForExample
-      - name: Unset JAVA_HOME
-        run: unset JAVA_HOME
       - name: Switch to JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/gradle-example.yml
+++ b/.github/workflows/gradle-example.yml
@@ -27,10 +27,14 @@ jobs:
         run: ./gradlew publishToMavenLocal -PdisableCheckstyle -PdisableJacoco -PdisablePmd -x test
       - name: Set dependency versions
         run: ./gradlew setDependenciesForExample
+      - name: Unset JAVA_HOME
+        run: unset JAVA_HOME
       - name: Switch to JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Show java version
+        run: java -version
       - name: Run Junit5 example
         run: cd ./examples/junit-5 && ./gradlew build
       - name: Run Junit4 example

--- a/.github/workflows/gradle-example.yml
+++ b/.github/workflows/gradle-example.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages
@@ -27,6 +27,10 @@ jobs:
         run: ./gradlew publishToMavenLocal -PdisableCheckstyle -PdisableJacoco -PdisablePmd -x test
       - name: Set dependency versions
         run: ./gradlew setDependenciesForExample
+      - name: Switch to JDK 1.8
+          uses: actions/setup-java@v1
+          with:
+            java-version: 1.8
       - name: Run Junit5 example
         run: cd ./examples/junit-5 && ./gradlew build
       - name: Run Junit4 example

--- a/.github/workflows/gradle-regression-jdk8.yml
+++ b/.github/workflows/gradle-regression-jdk8.yml
@@ -1,4 +1,4 @@
-name: regression-testing
+name: regression-testing-jdk8
 
 on:
   pull_request:
@@ -11,19 +11,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 1.8
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-regression-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-regression-gradle
+          key: ${{ runner.os }}-regression-1.8-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-regression-1.8-gradle
       - name: Build with Gradle
         run: ./gradlew build -PexcludeMainTesting=true
         env:
-          RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK: true
+          RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK: true

--- a/.github/workflows/gradle-regression.yml
+++ b/.github/workflows/gradle-regression.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,21 @@ subprojects {
 
     // Add flag to run specific group of tests
     apply from: "$rootProject.projectDir/on-off-test.gradle"
+
+    // Compile with Java9 + while keeping Java8 compatibility
+    if (JavaVersion.current().java9Compatible) {
+        project.afterEvaluate {
+            tasks.withType(JavaCompile) {
+                def version = sourceCompatibility.contains('.')
+                        ? sourceCompatibility
+                        : sourceCompatibility.substring(sourceCompatibility.lastIndexOf('.')+1)
+                project.logger.info("Configuring $name to use --release $version")
+                options.compilerArgs.addAll(['--release', version])
+            }
+        }
+    } else {
+        project.logger.warn("-PcrossCompile not supported prior to JDK 9; using JDK ${JavaVersion.current()}")
+    }
 }
 
 task setDependenciesForExample {

--- a/build.gradle
+++ b/build.gradle
@@ -74,19 +74,18 @@ subprojects {
     // Add flag to run specific group of tests
     apply from: "$rootProject.projectDir/on-off-test.gradle"
 
-    // Compile with Java9 + while keeping Java8 compatibility
+    // Keep Java8 compatibility
     if (JavaVersion.current().java9Compatible) {
         project.afterEvaluate {
             tasks.withType(JavaCompile) {
-                def version = sourceCompatibility.contains('.')
-                        ? sourceCompatibility
-                        : sourceCompatibility.substring(sourceCompatibility.lastIndexOf('.')+1)
+                def version = "8"
                 project.logger.info("Configuring $name to use --release $version")
                 options.compilerArgs.addAll(['--release', version])
             }
         }
     } else {
-        project.logger.warn("-PcrossCompile not supported prior to JDK 9; using JDK ${JavaVersion.current()}")
+        project.logger.warn("-PcrossCompile not supported prior to JDK 9. "
+                + "Current JDK is ${JavaVersion.current()}")
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,8 +11,23 @@ include 'schemaregistry-junit-core',
 if (System.env.EXCLUDE_REGRESSION != 'true') {
     // Automatically add all modules inside the regression-test folder
     file('schemaregistry-junit-test/schemaregistry-junit-regression-test').eachDir { dir ->
-        if (dir.name != 'build')
-            include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+        if (dir.name != 'build') {
+            if (System.env.RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK == 'true') {
+                // Versions older than 5.0 requires JDK 1.8 to run.
+                // RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK can be used to exclude tests requiring
+                // an older JDK
+                if (!dir.name.contains("4."))
+                    include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+            } else if (System.env.RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK == 'true') {
+                // Versions older than 5.0 requires JDK 1.8 to run.
+                // RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK can be used to run only these tests using
+                // a JDK 1.8
+                if (dir.name.contains("4."))
+                    include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+            } else {
+                include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+            }
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,20 +12,25 @@ if (System.env.EXCLUDE_REGRESSION != 'true') {
     // Automatically add all modules inside the regression-test folder
     file('schemaregistry-junit-test/schemaregistry-junit-regression-test').eachDir { dir ->
         if (dir.name != 'build') {
-            if (System.env.RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK == 'true') {
-                // Versions older than 5.0 requires JDK 1.8 to run.
-                // RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK can be used to exclude tests requiring
-                // an older JDK
-                if (!dir.name.contains("4."))
-                    include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
-            } else if (System.env.RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK == 'true') {
-                // Versions older than 5.0 requires JDK 1.8 to run.
-                // RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK can be used to run only these tests using
-                // a JDK 1.8
-                if (dir.name.contains("4."))
-                    include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
-            } else {
+            // baseline module is required by all regression testing
+            if (dir.name == 'baseline') {
                 include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+            } else {
+                if (System.env.RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK == 'true') {
+                    // Versions older than 5.0 requires JDK 1.8 to run.
+                    // RUN_ONLY_REGRESSION_SUPPORTING_NEW_JDK can be used to exclude tests requiring
+                    // an older JDK
+                    if (!dir.name.contains("4."))
+                        include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+                } else if (System.env.RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK == 'true') {
+                    // Versions older than 5.0 requires JDK 1.8 to run.
+                    // RUN_ONLY_REGRESSION_REQUIRING_OLD_JDK can be used to run only these tests using
+                    // a JDK 1.8
+                    if (dir.name.contains("4."))
+                        include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+                } else {
+                    include "schemaregistry-junit-test:schemaregistry-junit-regression-test:${dir.name}"
+                }
             }
         }
     }


### PR DESCRIPTION
Compile project with Java 11 while keeping compatibility with Java 8.

SchemaRegistry versions pre 5.x.x are regression tested using JDK 8, while for all versions higher or equal than 5 JDK 11 is used.

CI pipeline for examples uses JDK 11 to compile the local version of schemaregistry-junit, but then rely on JDK 8 to compile and test all example projects.